### PR TITLE
Bug in the "s.files" glob

### DIFF
--- a/Rakefile.erb
+++ b/Rakefile.erb
@@ -63,7 +63,7 @@ spec = Gem::Specification.new do |s|
 
   # Add any extra files to include in the gem (like your README)
 <% end %>
-  s.files             = %w(<%= files_in_root %>) + Dir.glob("{<%= dirs_to_include_glob %>}")
+  s.files             = %w(<%= files_in_root %>) + Dir.glob(<%= dirs_to_include_glob.inspect %>)
 <% if has_executables? %>
   s.executables       = FileList["bin/**"].map { |f| File.basename(f) }
 <% end %>

--- a/lib/gem_this.rb
+++ b/lib/gem_this.rb
@@ -84,11 +84,11 @@ class GemThis
 
   def dirs_to_include_glob
     dirs = %w(bin test spec lib).select { |d| File.directory?(d) }
+    glob_parts = ["**", "*"]
     if dirs.any?
-      dirs.join(",") + "/**/*"
-    else
-      "**/*"
+      glob_parts.unshift("{"+dirs.join(",")+"}")
     end
+    File.join(*glob_parts)
   end
 
   def readme

--- a/test/gem_this_test.rb
+++ b/test/gem_this_test.rb
@@ -6,11 +6,16 @@ class GemThisTest < Test::Unit::TestCase
       build_gem do
         touch "README"
         touch "lib/thing.rb"
+        touch "lib/thing/some/aspect/many/levels/deep.rb"
       end
     end
 
     should "contain lib files" do
       assert_gem_contains "lib/thing.rb"
+    end
+    
+    should "contain deeply nested files" do
+      assert_gem_contains "lib/thing/some/aspect/many/levels/deep.rb"
     end
 
     should "include the README" do

--- a/test/gem_this_test.rb
+++ b/test/gem_this_test.rb
@@ -4,8 +4,8 @@ class GemThisTest < Test::Unit::TestCase
   context "When building a gem" do
     setup do
       build_gem do
-        file "README"
-        lib %w(thing.rb)
+        touch "README"
+        touch "lib/thing.rb"
       end
     end
 
@@ -25,8 +25,8 @@ class GemThisTest < Test::Unit::TestCase
   context "When building a gem with specs" do
     setup do
       build_gem do
-        lib %w(thing.rb)
-        spec %w(my_spec.rb)
+        touch "lib/thing.rb"
+        touch "spec/my_spec.rb"
       end
     end
 
@@ -38,8 +38,8 @@ class GemThisTest < Test::Unit::TestCase
   context "When building a gem with features" do
     setup do
       build_gem do
-        lib %(thing.rb)
-        features %w(gem-this.feature)
+        touch "lib/thing.rb"
+        touch "features/gem-this.feature"
       end
     end
 
@@ -55,7 +55,7 @@ class GemThisTest < Test::Unit::TestCase
   context "When building a gem without a lib directory" do
     setup do
       create_gem do
-        code %w(my_code_is_in_here_for_some_reason.rb)
+        touch "code/my_code_is_in_here_for_some_reason.rb"
       end
     end
 

--- a/test/gem_this_test.rb
+++ b/test/gem_this_test.rb
@@ -21,6 +21,24 @@ class GemThisTest < Test::Unit::TestCase
       assert_gem_spec :require_paths, ["lib"]
     end
   end
+  
+  context "When building a gem with tests" do
+    setup do
+      build_gem do
+        touch "lib/thing.rb"
+        touch "test/thing_test.rb"
+      end
+    end
+
+    should "contain test files" do
+      assert_gem_contains "test/thing_test.rb"
+    end
+    
+    should "create a rake task for running tests" do
+      assert_rake_task :test
+    end
+    
+  end
 
   context "When building a gem with specs" do
     setup do
@@ -28,6 +46,10 @@ class GemThisTest < Test::Unit::TestCase
         touch "lib/thing.rb"
         touch "spec/my_spec.rb"
       end
+    end
+    
+    should "contain spec files" do
+      assert_gem_contains "spec/my_spec.rb"
     end
 
     should "create a rake task for running specs" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,20 +18,8 @@ class GemBuilder
     end
   end
 
-  def method_missing(name, *args)
-    in_directory(name) do
-      args.each { |f| file(f) }
-      yield if block_given?
-    end
-  end
-
-  def in_directory(name, &block)
-    path = File.join(@gem_path, name.to_s)
-    FileUtils.mkdir_p(path)
-    FileUtils.cd(path, &block)
-  end
-
-  def file(name)
+  def touch(name)
+    FileUtils.mkdir_p(File.dirname(name))
     FileUtils.touch(name)
   end
 


### PR DESCRIPTION
Example:
https://github.com/matthewrudy/i18n_scope/blob/5b55497cc3c15098cc441676b2f18264aa29a251/Rakefile#L61

Dir.glob("{test,lib/*_/_}")
doesn't pull in the test files

Dir.glob("{test,lib}/*_/_") is correct

I also took the liberty of removing some method missing magic from the tests.
(notably the spec tests fail, but they did before..)
