### PR TITLE
Change RSpec --format option from 'specdoc' to 'documentation'

### DIFF
--- a/Rakefile.erb
+++ b/Rakefile.erb
@@ -6,7 +6,7 @@ require "rake/rdoctask"
 require "rspec"
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new do |t|
-  t.rspec_opts = %w(--format specdoc --colour)
+  t.rspec_opts = %w(--format documentation --colour)
 end
 <% elsif using_test_unit? %>
 require "rake/testtask"


### PR DESCRIPTION
Using gem-this generated Rakefiles with RSpec 2.6 throws an ArgumentError exception trying to use the specdoc formatter.

```
.../rspec-core-2.6.4/lib/rspec/core/configuration.rb:281:in `add_formatter': Formatter 'specdoc' unknown - maybe you meant 'documentation' or 'progress'?. (ArgumentError)
```

This pull request makes the change in the Rakefile ERB template to use the documentation formatter.
