### PR TITLE
Remove deprecated `has_rdoc` option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ spec = Gem::Specification.new do |s|
   s.email             = "james@lazyatom.com"
   s.homepage          = "http://github.com/lazyatom/gem-this"
 
-  s.has_rdoc          = true
   # s.extra_rdoc_files  = %w(Readme.markdown)
   # s.rdoc_options      = %w(--main Readme.markdown)
 

--- a/Rakefile.erb
+++ b/Rakefile.erb
@@ -48,7 +48,6 @@ spec = Gem::Specification.new do |s|
   s.email             = "<%= author_email %>"
   s.homepage          = "<%= author_url %>"
 
-  s.has_rdoc          = true
 <% if readme %>
   s.extra_rdoc_files  = %w(<%= readme %>)
   s.rdoc_options      = %w(--main <%= readme %>)


### PR DESCRIPTION
Using or packaging the gem as is results in the
following warning:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/david/Documents/projects/gem-this/Rakefile:29.
```